### PR TITLE
feat: mirror analytics to the GTM dataLayer (Google Ads)

### DIFF
--- a/.changeset/datalayer-integration.md
+++ b/.changeset/datalayer-integration.md
@@ -1,0 +1,5 @@
+---
+'@obelism/improve-sdk': minor
+---
+
+Add GTM / Google Ads dataLayer integration. The client SDK's `postAnalytic` now mirrors each event onto `window.dataLayer` with experiment dimensions (`improve: { test, variant, visitorId }`, tagged `_improve` for loop prevention), so events can drive Google Tag Manager / Google Ads conversions. Enabled by default; opt out with `dataLayer: false` in the setup args.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -24,6 +24,7 @@ constructor({
 	environment: 'develop' | 'staging' | 'production'
 	config?: Configuration
 	fetchTimeout?: number
+	dataLayer?: boolean
 }) => void
 ```
 
@@ -31,6 +32,7 @@ constructor({
 - **environment** - Application environment, can be one of three values
 - **config** - (optional) Configuration file, this can be either fetched or provided on initialization
 - **fetchTimeout** - (optional) When fetching the config after what amount of ms should it abort, default; 3000ms
+- **dataLayer** - (optional) Mirror analytics onto the GTM `window.dataLayer` (with `improve: { test, variant, visitorId }` dimensions) so they can drive Google Tag Manager / Google Ads conversions. Default; `true`, set to `false` to opt out
 
 ### fetchConfig
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -5,6 +5,7 @@ import { BaseImproveSDK } from './base'
 import { getCookie, setCookie } from './utils/clientCookie'
 import { ANALYTICS_PATH, BASE_URL } from './config/urls'
 import { getScreenSize } from './utils/getScreenSize'
+import { pushDataLayer } from './utils/pushDataLayer'
 import { ImproveEnvironmentOption, ImproveSetupArgs } from './types'
 
 type Visitor = ParsedUserAgent & {
@@ -46,11 +47,14 @@ export class ImproveClientSDK extends BaseImproveSDK {
 
 	#analyticsUrl = `${BASE_URL}${ANALYTICS_PATH}`
 
+	#dataLayerEnabled: boolean = true
+
 	fetchConfig = this._fetchConfig
 
 	constructor(args: ImproveSetupArgs) {
 		super(args)
 		this.#analyticsUrl = `${this._baseUrl}${ANALYTICS_PATH}`
+		this.#dataLayerEnabled = args.dataLayer ?? true
 	}
 
 	setupVisitor = (userAgent: string = window.navigator.userAgent) => {
@@ -187,6 +191,18 @@ export class ImproveClientSDK extends BaseImproveSDK {
 			visitor: this.#visitorRecurring ? 'recurring' : 'new',
 			event: event,
 			message: message || '',
+		}
+
+		if (this.#dataLayerEnabled) {
+			pushDataLayer({
+				event,
+				improve: {
+					test: testSlug,
+					variant: testValue,
+					visitorId: this.#visitorId,
+				},
+				_improve: true,
+			})
 		}
 
 		return fetch(this.#analyticsUrl, {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -11,6 +11,12 @@ export type ImproveSetupArgs = {
 	config?: ImproveConfiguration
 	baseUrl?: string
 	fetchTimeout?: number
+	/**
+	 * Mirror analytics onto the GTM dataLayer (window.dataLayer) with experiment
+	 * dimensions, so they can drive Google Tag Manager / Google Ads conversions.
+	 * Enabled by default; set to `false` to opt out. No effect server-side.
+	 */
+	dataLayer?: boolean
 }
 
 export type ImproveFlagOption = {

--- a/packages/sdk/src/utils/pushDataLayer.test.ts
+++ b/packages/sdk/src/utils/pushDataLayer.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, expect, test } from 'vitest'
+
+import { ImproveDataLayerEntry, pushDataLayer } from './pushDataLayer'
+
+const setWindow = (value: unknown) => {
+	;(globalThis as { window?: unknown }).window = value
+}
+
+afterEach(() => {
+	delete (globalThis as { window?: unknown }).window
+})
+
+const entry: ImproveDataLayerEntry = {
+	event: 'pageLoad',
+	improve: { test: 'hero', variant: 'b', visitorId: 'visi_X' },
+	_improve: true,
+}
+
+test('initializes the dataLayer and pushes the entry', () => {
+	setWindow({})
+
+	pushDataLayer(entry)
+
+	expect((globalThis as { window: Window }).window.dataLayer).toEqual([entry])
+})
+
+test('appends when GTM already created the dataLayer', () => {
+	setWindow({ dataLayer: [{ event: 'gtm.js' }] })
+
+	pushDataLayer(entry)
+
+	const { dataLayer } = (globalThis as { window: Window }).window
+	expect(dataLayer).toHaveLength(2)
+	expect(dataLayer?.[1]).toEqual(entry)
+})
+
+test('is a no-op without a window (server-side)', () => {
+	expect(() => pushDataLayer(entry)).not.toThrow()
+})

--- a/packages/sdk/src/utils/pushDataLayer.ts
+++ b/packages/sdk/src/utils/pushDataLayer.ts
@@ -1,0 +1,31 @@
+export type ImproveDataLayerEntry = {
+	event: string
+	improve: {
+		test: string
+		variant: string
+		visitorId: string
+	}
+	/**
+	 * Marks the entry as originating from Improve so platform-side dataLayer
+	 * importers can ignore it (loop prevention).
+	 */
+	_improve: true
+}
+
+declare global {
+	interface Window {
+		dataLayer?: Record<string, unknown>[]
+	}
+}
+
+/**
+ * Mirror an analytic onto the GTM dataLayer (with experiment dimensions) so it
+ * can drive Google Tag Manager / Google Ads conversions. No-op outside the
+ * browser. Initializes window.dataLayer if GTM hasn't yet.
+ */
+export const pushDataLayer = (entry: ImproveDataLayerEntry) => {
+	if (typeof window === 'undefined') return
+
+	window.dataLayer = window.dataLayer || []
+	window.dataLayer.push(entry)
+}


### PR DESCRIPTION
Native dataLayer support in the SDK, so customer sites get the same GTM / Google Ads integration we just built into the Improve platform (events on the dataLayer, segmentable by experiment variant).

## What changes
- **`ImproveClientSDK.postAnalytic`** now mirrors each event onto `window.dataLayer`:
  ```js
  window.dataLayer.push({
    event,
    improve: { test, variant, visitorId },
    _improve: true,
  })
  ```
  The `improve.*` dimensions let Google Ads / GTM segment conversions by variant; `_improve: true` tags the entry so the platform's dataLayer importer ignores it (no loop). Initializes `window.dataLayer` if GTM hasn't yet, and is a no-op server-side.
- **New `dataLayer?: boolean` setup arg** (in `ImproveSetupArgs`). **Enabled by default**; set `dataLayer: false` to opt out.
- The **React SDK** (`usePostAnalytic`) delegates to this client method, so it's covered automatically — no react-sdk change needed.
- New `utils/pushDataLayer.ts` + tests, README option docs, and a changeset (minor).

## Why default on
The platform initiative is "all analytics also on the dataLayer." Pushing is additive and safe — with no GTM present, `dataLayer` is just an array; entries are namespaced (`improve.*`) and flagged. Opt out per the new arg if undesired.

## Verification
- ✅ `@obelism/improve-sdk` tests pass (16, incl. 3 new for `pushDataLayer`: init, append-to-existing-GTM-dataLayer, SSR no-op)
- ✅ `lint` (tsc + eslint) clean
- ✅ `build` (bunchee) green

## Notes for the platform side
- The Improve app currently runs an app-level dataLayer bridge (wrapping `usePostAnalytic`). Once the app upgrades to this SDK version, it should drop that wrapper push to avoid double dataLayer entries (both are `_improve`-tagged, so no import loop — just a duplicate GTM event).
- **Not included (follow-up):** the *inbound* direction (SDK proxying `dataLayer.push` to auto-register custom events + forward funnel events) — that's a larger addition; this PR covers the outbound push + toggle.

https://claude.ai/code/session_01U8qxuJSLoaqqBU8j8JMyeC