### PR TITLE
fix: de-flake server test + correct turbo lint build ordering

### DIFF
--- a/packages/sdk/src/server.test.ts
+++ b/packages/sdk/src/server.test.ts
@@ -64,7 +64,13 @@ test('1000 times getTestValue with new visitor ids', () => {
 
 	const delta = diff(...(Object.values(outcomeCount) as [number, number]))
 
-	expect(delta).toBeLessThanOrEqual(iterations / 15)
+	// getTestValue assigns each variant with Math.random, so a 50/50 split is
+	// binomially distributed: the delta between the two buckets has a standard
+	// deviation of ~sqrt(iterations). Allow ~5 standard deviations so the test
+	// effectively never flakes while still catching a grossly skewed split.
+	const maxDelta = Math.ceil(Math.sqrt(iterations) * 5)
+
+	expect(delta).toBeLessThanOrEqual(maxDelta)
 })
 
 test('200 runs with 100 different visitor IDS', () => {

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,7 @@
 			"env": ["EDGE_CONFIG"]
 		},
 		"lint": {
-			"dependsOn": ["^lint"]
+			"dependsOn": ["^build"]
 		},
 		"dev": {
 			"cache": false,


### PR DESCRIPTION
Two CI fixes (follow-ups to #171).

## 1. Flaky server split-distribution test

`src/server.test.ts` → *"1000 times getTestValue with new visitor ids"* failed ~3–4% of runs. `getTestValue` assigns variants with `Math.random()`, so a 50/50 split over 1000 draws is binomial with delta std ≈ √1000 ≈ 32; the old tolerance `iterations / 15` ≈ 66.7 is only ~2.1σ. Now bounded at ~5σ (`ceil(√iterations × 5)` ≈ 159) — effectively never flakes, still catches a grossly skewed split. Verified over 2000 simulated trials (max delta 136, zero exceedances).

## 2. Turbo lint build ordering (fixes the publish workflow)

`react-sdk`/`next-sdk` `lint:types` (`tsc --noEmit`) import types from `@obelism/improve-sdk`'s built `.d.ts` (e.g. `@obelism/improve-sdk/client`). The turbo `lint` task only depended on `^lint`, so in a clean run `tsc` could execute before the dependency was built, failing with `Cannot find module '@obelism/improve-sdk/client'` and cascading TS errors. This broke the publish workflow on `main`. Changed `lint` to depend on `^build`.

Verified: `turbo run build lint test --filter='./packages/*' --force` passes 9/9 from a fully clean state.

Test/config-only changes; no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)