### PR TITLE
docs: add hono example preview URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The official [Obelism Improve](https://improve.obelism.studio) SDK
 ### Examples
 
 - `html`: a static html website using the Improve JS SDK; [preview](https://html.improve.obelism.studio)
-- `hono`: a Hono app using the Improve Server React SDK
+- `hono`: a Hono app using the Improve Server SDK; [preview](https://hono.improve.obelism.studio)
 - `react`: a React app using the Improve React SDK; [preview](https://react.improve.obelism.studio)
 - `nextjs`: a NextJS app using the Improve NextJS and React SDK; [preview](https://nextjs.improve.obelism.studio)
 - `nextjs-vercel`: a NextJS app using the Improve NextJS and React SDK and Vercel Edge Storage; [preview](https://nextjs-vercel.improve.obelism.studio)


### PR DESCRIPTION
Every example in the README now links to its live preview. `hono` was the only one missing a preview link — added `https://hono.improve.obelism.studio` (verified live, returns `AB Test: variation`). Also corrected the hono description: it uses the **Server SDK**, not the React SDK.

All five preview domains verified resolving (HTTP 200): html, hono, react, nextjs, nextjs-vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)