### PR TITLE
fix(sdk): scope postAnalytic dedup to event+dedupeKey

### DIFF
--- a/.changeset/wild-donuts-report.md
+++ b/.changeset/wild-donuts-report.md
@@ -1,0 +1,25 @@
+---
+'@obelism/improve-sdk': minor
+---
+
+`postAnalytic`'s per-session dedup now supports a `dedupeKey` payload field.
+
+Previously `postAnalytic` deduped purely by event name, so any event fired more
+than once per page/session under the same name (e.g. a GA4-style
+`view_promotion` or `view_item_list` fired once per item/promotion) would only
+actually send the first time — every later call silently no-op'd.
+
+Passing `dedupeKey` scopes the dedup to `event` + `dedupeKey` instead, so the
+same event name can fire once per distinct subject:
+
+```ts
+postAnalytic('view_promotion', {
+	message: 'Hero',
+	params: { type: 'Hero' },
+	dedupeKey: 'Hero',
+})
+```
+
+Omitting `dedupeKey` keeps the existing once-per-event-name-per-session
+behavior, so this is non-breaking for existing callers (`page_view`,
+`purchase`, `sign_up`, ...).

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -69,7 +69,8 @@ export type CreateExposure = BeaconCommon<'exposure'> & {
 	variant: string
 }
 
-// Events already sent this instance, so each fires at most once per page/session.
+// Events already sent this instance, keyed by event name (or `event:dedupeKey`
+// when the caller passes one), so each fires at most once per page/session.
 type TrackedEvents = {
 	[event: string]: boolean
 }
@@ -346,7 +347,13 @@ export class ImproveClientSDK extends BaseImproveSDK {
 		// tracked, so it can still fire once the cooldown elapses.
 		if (Date.now() < this.#rateLimitedUntil) return null
 
-		const { value, currency, message, params }: ImproveAnalyticPayload =
+		const {
+			value,
+			currency,
+			message,
+			params,
+			dedupeKey,
+		}: ImproveAnalyticPayload =
 			typeof payload === 'string' ? { message: payload } : (payload ?? {})
 		const hasValue = typeof value === 'number' && Number.isFinite(value)
 		// The backend requires `params` to be a plain (non-array) object and 400s
@@ -361,10 +368,13 @@ export class ImproveClientSDK extends BaseImproveSDK {
 
 		// The event is test-independent: it's recorded once per visitor and later
 		// attributed to whichever tests/flags the visitor was exposed to. Dedup per
-		// event name so it fires at most once per page/session.
-		if (!this.#visitor || this.#analytics[event]) return null
+		// event name (or per `event:dedupeKey`, when the caller distinguishes
+		// repeated firings of the same name) so it fires at most once per
+		// page/session.
+		const trackingKey = dedupeKey ? `${event}:${dedupeKey}` : event
+		if (!this.#visitor || this.#analytics[trackingKey]) return null
 
-		this.#analytics[event] = true
+		this.#analytics[trackingKey] = true
 
 		const body: CreateEvent = {
 			...this.#beaconCommon('event'),
@@ -399,6 +409,6 @@ export class ImproveClientSDK extends BaseImproveSDK {
 			})
 		}
 
-		return this.#send(body, event)
+		return this.#send(body, trackingKey)
 	}
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -131,6 +131,8 @@ export type ImproveEvents = {
  *   not aggregated by Improve's own results. Use it for a GA4 `ecommerce`
  *   object (`{ ecommerce: { items: [...] } }`) or any custom event parameters.
  * - `message` is kept for the simple single-string case.
+ * - `dedupeKey` distinguishes repeated firings of the same event name — see
+ *   below.
  *
  * `postAnalytic` also accepts a plain string as a shorthand for `{ message }`.
  */
@@ -147,6 +149,16 @@ export type ImproveAnalyticPayload = {
 	 * the previous `ecommerce` object first to avoid data bleed between events.
 	 */
 	params?: Record<string, unknown>
+	/**
+	 * Distinguishes multiple firings of the same event name within one
+	 * page/session, e.g. an item or promotion id for a `view_promotion` /
+	 * `view_item_list` fired once per item. `postAnalytic` dedupes per `event`
+	 * name by default; passing a `dedupeKey` scopes that dedup to `event` +
+	 * `dedupeKey` instead, so the same event name can fire once per distinct
+	 * subject rather than only once total. Not sent to the server or the
+	 * dataLayer — local dedup only.
+	 */
+	dedupeKey?: string
 }
 
 export type ImproveResult = {


### PR DESCRIPTION
## Summary
- `postAnalytic()` deduped purely by event name, once per page/session. Any event fired more than once under the same name (e.g. a GA4-style `view_promotion` fired once per promotion item/block) only ever sent on the first call — every later call silently no-op'd.
- Adds an optional `dedupeKey` field to `ImproveAnalyticPayload`. When passed, dedup scopes to `event:dedupeKey` instead of `event` alone. Omitting it keeps the current behavior, so this is non-breaking for existing single-fire events (`page_view`, `purchase`, `sign_up`, ...).
- Includes a changeset for a minor version bump on `@obelism/improve-sdk`.

## Test plan
- [x] `turbo run test --filter='./packages/sdk'` — 57 tests pass
- [x] `turbo run lint build --filter='./packages/sdk'` — passes (pre-existing warnings only, unrelated to this change)