### PR TITLE
Require scope as postAnalytic's second argument, replacing message

### DIFF
--- a/.changeset/proud-otters-teach.md
+++ b/.changeset/proud-otters-teach.md
@@ -1,0 +1,33 @@
+---
+'@obelism/improve-sdk': major
+---
+
+`postAnalytic`'s `message` field is replaced by a required `scope` positional
+argument.
+
+Previously the second half of an event's identity (`message`) was optional
+free text — in practice used inconsistently across integrations (a URL path
+on one event, a button label on another, often left empty). `scope` makes
+that second dimension mandatory and structured: a short, stable identifier
+for where/what the event refers to, always present, not display text.
+
+```ts
+// Before
+postAnalytic('button_click', {
+	message: 'Sign in',
+	params: { label: 'Sign in' },
+})
+
+// After
+postAnalytic('button_click', 'homepage_hero_login', {
+	params: { label: 'Sign in' },
+})
+```
+
+The plain-string shorthand (`postAnalytic(event, 'some message')`) is removed
+— the shorthand for the common case is now simply passing `scope` directly:
+`postAnalytic('page_view', 'homepage')`.
+
+`ImproveEvents`' `start`/`metrics`/`conversion` fields change from bare event
+names to `{ event, scope }` pairs (`ImproveEventRef`) to match. `funnel`, and
+exposure tracking (`getTestValue`/`getFlagValue`), are unaffected.

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -69,7 +69,7 @@ Wrapper around [getTestValue](https://improve.obelism.studio/docs/sdk/javascript
 ```ts
 const postAnalytic = usePostAnalytic()
 
-<button onClick={() => postAnalytic(testSlug: string, eventSlug: string, message: string)} />
+<button onClick={() => postAnalytic(event: string, scope: string)} />
 ```
 
 Wrapper around [postAnalytic](https://improve.obelism.studio/docs/sdk/javascript#postanalytic) that's passed down when the context is setup.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -112,9 +112,9 @@ getTestConfig(testSlug: string) => {
         split: number
     }[]
 	events: {
-        start: string
-        metrics: string[]
-        conversion: string
+        start: { event: string; scope: string }
+        metrics: { event: string; scope: string }[]
+        conversion: { event: string; scope: string }
     }
 } | undefined
 ```
@@ -178,8 +178,14 @@ Configure the analytics url to post message towards. Convenient in case add bloc
 ### postAnalytic
 
 ```ts
-postAnalytic = (testSlug: string, event: string, message?: string) =>
-	Promise<Response> | null
+postAnalytic = (
+	event: string,
+	scope: string,
+	payload?: ImproveAnalyticPayload,
+) => Promise<Response> | null
 ```
 
-Posts an analytics message to Improve or the url configured with [setAnalyticsUrls](/docs/sdk/javascript#setanalyticsurls)
+Posts an analytic event to Improve or the url configured with [setAnalyticsUrls](/docs/sdk/javascript#setanalyticsurls).
+`scope` is required — a short, stable identifier for where/what the event refers to
+(e.g. `"homepage_hero_login"`), distinct from the optional `value`/`currency`/`params`/
+`dedupeKey` extras in `payload`.

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -48,7 +48,7 @@ type BeaconCommon<T extends 'event' | 'exposure'> = {
  */
 export type CreateEvent = BeaconCommon<'event'> & {
 	event: string
-	message: string
+	scope: string
 
 	/** GA4-aligned numeric value aggregated into revenue / AOV per variant. */
 	value?: number
@@ -96,6 +96,10 @@ export class ImproveClientSDK extends BaseImproveSDK {
 	// Event names already warned about, so the snake_case nudge fires once per
 	// offending name instead of on every call.
 	#warnedEventNames = new Set<string>()
+
+	// Fires the missing-scope warning at most once per SDK instance, not once
+	// per call — a caller that forgets `scope` is likely forgetting it everywhere.
+	#warnedMissingScope = false
 
 	#analyticsUrl = `${BASE_URL}${ANALYTICS_PATH}`
 
@@ -320,9 +324,11 @@ export class ImproveClientSDK extends BaseImproveSDK {
 
 	postAnalytic = (
 		event: ImproveEventName,
-		// Accepts a structured payload, or a plain string as shorthand for the
-		// `message`.
-		payload?: ImproveAnalyticPayload | string,
+		// Required, freeform, but always present — the stable second half of the
+		// event's identity (e.g. "homepage_hero_login"). Not a display string;
+		// keep it structured and consistent, unlike the old `message` field.
+		scope: string,
+		payload?: ImproveAnalyticPayload,
 	) => {
 		if (!this.config) return null
 
@@ -343,18 +349,21 @@ export class ImproveClientSDK extends BaseImproveSDK {
 			)
 		}
 
+		if (!scope && !this.#warnedMissingScope) {
+			this.#warnedMissingScope = true
+			this._warn(
+				`postAnalytic("${event}", ...) was called with an empty scope. ` +
+					`scope is required — pass a short, stable identifier for where/what ` +
+					`this event refers to, e.g. "homepage_hero_login".`,
+			)
+		}
+
 		// Suspended after a 429: skip sending, but don't mark the event as
 		// tracked, so it can still fire once the cooldown elapses.
 		if (Date.now() < this.#rateLimitedUntil) return null
 
-		const {
-			value,
-			currency,
-			message,
-			params,
-			dedupeKey,
-		}: ImproveAnalyticPayload =
-			typeof payload === 'string' ? { message: payload } : (payload ?? {})
+		const { value, currency, params, dedupeKey }: ImproveAnalyticPayload =
+			payload ?? {}
 		const hasValue = typeof value === 'number' && Number.isFinite(value)
 		// The backend requires `params` to be a plain (non-array) object and 400s
 		// the whole event otherwise — drop an invalid value rather than lose the
@@ -382,7 +391,7 @@ export class ImproveClientSDK extends BaseImproveSDK {
 			// an over-length value is otherwise rejected with a 400 and the event
 			// is lost.
 			event: truncate(event, MAX_ANALYTIC_FIELD_LENGTH),
-			message: truncate(message || '', MAX_ANALYTIC_FIELD_LENGTH),
+			scope: truncate(scope || '', MAX_ANALYTIC_FIELD_LENGTH),
 			...(hasValue ? { value } : {}),
 			...(currency
 				? { currency: truncate(currency, MAX_CURRENCY_FIELD_LENGTH) }
@@ -397,6 +406,7 @@ export class ImproveClientSDK extends BaseImproveSDK {
 
 			pushDataLayer({
 				event,
+				scope,
 				improve: {
 					visitorId: this.#visitorId,
 				},

--- a/packages/sdk/src/config/constants.ts
+++ b/packages/sdk/src/config/constants.ts
@@ -18,7 +18,7 @@ export const CONFIG_RETRY_MAX_DELAY_MS = 3000
 /**
  * Max length of a single analytic string field. The backend rejects any
  * field longer than this (varchar(256)) with a 400, so the client caps
- * developer-controlled values (event, message) to avoid silently dropping
+ * developer-controlled values (event, scope) to avoid silently dropping
  * the event.
  */
 export const MAX_ANALYTIC_FIELD_LENGTH = 256

--- a/packages/sdk/src/server.test.ts
+++ b/packages/sdk/src/server.test.ts
@@ -34,9 +34,9 @@ const TEST_CONFIG: ImproveConfiguration = {
 				},
 			],
 			events: {
-				start: 'pageLoad',
+				start: { event: 'pageLoad', scope: 'homepage' },
 				metrics: [],
-				conversion: 'visualClicked',
+				conversion: { event: 'visualClicked', scope: 'homepage' },
 			},
 		},
 	},

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -107,10 +107,22 @@ export type ImproveRecommendedEventName =
  */
 export type ImproveEventName = ImproveRecommendedEventName | (string & {})
 
+/**
+ * An event name paired with its required, freeform `scope` — the one
+ * consistent key/value identity used everywhere (SDK, dashboard, test setup):
+ * e.g. `{ event: 'button_click', scope: 'homepage_hero_login' }`. Unlike
+ * `message` in previous SDK versions, `scope` is mandatory and expected to be
+ * a stable, structured string (not display text) — see `postAnalytic`.
+ */
+export type ImproveEventRef = {
+	event: ImproveEventName
+	scope: string
+}
+
 export type ImproveEvents = {
-	start: ImproveEventName
-	metrics: ImproveEventName[]
-	conversion: ImproveEventName
+	start: ImproveEventRef
+	metrics: ImproveEventRef[]
+	conversion: ImproveEventRef
 	/**
 	 * Ordered funnel steps for the multi-step conversion view, when the test
 	 * defines one. The last step is the conversion; when absent, the funnel is
@@ -121,7 +133,8 @@ export type ImproveEvents = {
 
 /**
  * Structured payload for an analytic event, aligned with Google Analytics 4
- * event parameters.
+ * event parameters. `event` and `scope` are passed as `postAnalytic`'s first
+ * two (required) arguments — everything here is optional extras.
  *
  * - `value` (with `currency`) is the numeric measure Improve aggregates into
  *   **revenue / average order value per variant** — pass an order total on your
@@ -130,19 +143,14 @@ export type ImproveEvents = {
  * - `params` is passed through to the GTM dataLayer and stored as JSON, but is
  *   not aggregated by Improve's own results. Use it for a GA4 `ecommerce`
  *   object (`{ ecommerce: { items: [...] } }`) or any custom event parameters.
- * - `message` is kept for the simple single-string case.
  * - `dedupeKey` distinguishes repeated firings of the same event name — see
  *   below.
- *
- * `postAnalytic` also accepts a plain string as a shorthand for `{ message }`.
  */
 export type ImproveAnalyticPayload = {
 	/** Numeric value of the event, e.g. an order total. GA4 `value`. */
 	value?: number
 	/** ISO 4217 currency code for `value`, e.g. `'USD'`. GA4 `currency`. */
 	currency?: string
-	/** A short freeform label stored alongside the event. */
-	message?: string
 	/**
 	 * Extra event parameters, spread onto the GTM dataLayer entry and stored as
 	 * JSON. Provide `{ ecommerce: {...} }` for GA4 ecommerce tags; the SDK clears


### PR DESCRIPTION
message was optional free text used inconsistently across integrations (a path on one event, a label on another, often empty). scope makes that second half of an event's identity mandatory and structured, as a required positional argument rather than a payload field — matching how event itself is already enforced.

BREAKING CHANGE: postAnalytic(event, payload?) is now postAnalytic(event, scope, payload?). The string-shorthand form is removed. ImproveEvents' start/metrics/conversion change from bare event names to {event, scope} pairs.